### PR TITLE
Fix CSR key size to 4096 bits

### DIFF
--- a/modules/servers/openprovider_ssl/classes/HandleCSRCreation.php
+++ b/modules/servers/openprovider_ssl/classes/HandleCSRCreation.php
@@ -34,7 +34,7 @@ class HandleCSRCreation
             parse_str($data, $dataArray);
 
             $postData = [
-                "bits" => (int) 4098,
+                "bits" => (int) 4096,
                 "common_name" => $vars['domain'],
                 "country" => $dataArray['country'],
                 "email" => $dataArray['email'],

--- a/modules/servers/openprovider_ssl/hooks.php
+++ b/modules/servers/openprovider_ssl/hooks.php
@@ -152,7 +152,7 @@ add_hook('AdminAreaHeadOutput', 1, function ($vars) {
                     parse_str($data, $dataArray);
 
                     $postData = [
-                        "bits" => (int) 4098,
+                        "bits" => (int) 4096,
                         "common_name" => $dataArray['common_name'],
                         "country" => $dataArray['country'],
                         "email" => $dataArray['email'],


### PR DESCRIPTION
Fixed CSR key size to 4096 bits.

Changed files: 
- modules/servers/openprovider_ssl/classes/HandleCSRCreation.php
- modules/servers/openprovider_ssl/hooks.php