### PR TITLE
Intgrtns 559 whmcs ssl module v2.0.7 data truncation in csr generation approver email and host names empty incomplete

### DIFF
--- a/modules/servers/openprovider_ssl/openprovider_ssl.php
+++ b/modules/servers/openprovider_ssl/openprovider_ssl.php
@@ -307,21 +307,7 @@ function openprovider_ssl_CreateAccount(array $params)
         $apiCall = new ApiCall();
         $serviceId = $params['serviceid'];
         $pid = $params['pid'];
-        logModuleCall(
-            'Openprovider SSL Debug',
-            'CreateAccount Params',
-            [
-                'domain' => $params['domain'] ?? null,
-                'customfields' => $params['customfields'] ?? null,
-                'configoptions' => $params['configoptions'] ?? null,
-                'configoption1' => $params['configoption1'] ?? null,
-                'configoption2' => $params['configoption2'] ?? null,
-                'configoption3' => $params['configoption3'] ?? null,
-                'configoption4' => $params['configoption4'] ?? null,
-                'configoption5' => $params['configoption5'] ?? null,
-            ],
-            ''
-        );
+
         $handle = $helper->getClientCustomField($params['userid']);
 
         $orgnizationHandle = "";
@@ -396,17 +382,16 @@ function openprovider_ssl_CreateAccount(array $params)
             "signature_hash_algorithm" => $params['configoption4'],
         ];
 
-        // $createOrder = $apiCall->post($baseUrl . '/ssl/orders', $postData, "Create order");
+        $createOrder = $apiCall->post($baseUrl . '/ssl/orders', $postData, "Create order");
 
-        // if ($createOrder['httpcode'] != 200) {
-        //     return $createOrder['result']->desc;
-        // }
+        if ($createOrder['httpcode'] != 200) {
+            return $createOrder['result']->desc;
+        }
 
-        // $fields = ["ssl_id" => $createOrder['result']->data->id, "organization_handle" => $orgnizationHandle];
-        // $helper->insert_custom_fields_value($serviceId, $pid, $fields);
+        $fields = ["ssl_id" => $createOrder['result']->data->id, "organization_handle" => $orgnizationHandle];
+        $helper->insert_custom_fields_value($serviceId, $pid, $fields);
 
-        // logModuleCall('Openprovider SSL', __FUNCTION__, $postData, $createOrder['result']);
-        logModuleCall('Openprovider SSL', __FUNCTION__, $postData, "Create order API call is commented for testing purpose");
+        logModuleCall('Openprovider SSL', __FUNCTION__, $postData, $createOrder['result']);
         return "success";
     } catch (Exception $e) {
         logModuleCall('Openprovider SSL', __FUNCTION__, $params, $e->getMessage(), $e->getTraceAsString());

--- a/modules/servers/openprovider_ssl/openprovider_ssl.php
+++ b/modules/servers/openprovider_ssl/openprovider_ssl.php
@@ -370,19 +370,22 @@ function openprovider_ssl_CreateAccount(array $params)
             $orgnizationHandle = $handle;
         }
 
+        $domain = $params['customfields']['domain'] ?? '';
+        $emailDomain = preg_replace('/^\*\./', '', $domain);
+
         $postData = [
-            "approver_email" => $params['customfields']['approver_email'] . '@' . $params['domain'],
+            "approver_email" => $params['customfields']['approver_email'] . '@' . $emailDomain,
             "autorenew" => ($params['configoption2'] == 'on') ? 'on' : 'off',
             "csr" => $params['customfields']['csr'],
             "domain_amount" => $params['configoptions']['no_of_domain'],
             "domain_validation_methods" => [
                 [
-                    "host_name" => $params['domain'],
+                    "host_name" => $domain,
                     "method" => "email"
                 ],
             ],
             "host_names" => [
-                $params['domain'],
+                $domain,
             ],
             "organization_handle" => $orgnizationHandle,
             "enable_dns_automation" => ($params['configoption3'] == 'on') ? true : false,

--- a/modules/servers/openprovider_ssl/openprovider_ssl.php
+++ b/modules/servers/openprovider_ssl/openprovider_ssl.php
@@ -307,7 +307,21 @@ function openprovider_ssl_CreateAccount(array $params)
         $apiCall = new ApiCall();
         $serviceId = $params['serviceid'];
         $pid = $params['pid'];
-
+        logModuleCall(
+            'Openprovider SSL Debug',
+            'CreateAccount Params',
+            [
+                'domain' => $params['domain'] ?? null,
+                'customfields' => $params['customfields'] ?? null,
+                'configoptions' => $params['configoptions'] ?? null,
+                'configoption1' => $params['configoption1'] ?? null,
+                'configoption2' => $params['configoption2'] ?? null,
+                'configoption3' => $params['configoption3'] ?? null,
+                'configoption4' => $params['configoption4'] ?? null,
+                'configoption5' => $params['configoption5'] ?? null,
+            ],
+            ''
+        );
         $handle = $helper->getClientCustomField($params['userid']);
 
         $orgnizationHandle = "";

--- a/modules/servers/openprovider_ssl/openprovider_ssl.php
+++ b/modules/servers/openprovider_ssl/openprovider_ssl.php
@@ -396,16 +396,17 @@ function openprovider_ssl_CreateAccount(array $params)
             "signature_hash_algorithm" => $params['configoption4'],
         ];
 
-        $createOrder = $apiCall->post($baseUrl . '/ssl/orders', $postData, "Create order");
+        // $createOrder = $apiCall->post($baseUrl . '/ssl/orders', $postData, "Create order");
 
-        if ($createOrder['httpcode'] != 200) {
-            return $createOrder['result']->desc;
-        }
+        // if ($createOrder['httpcode'] != 200) {
+        //     return $createOrder['result']->desc;
+        // }
 
-        $fields = ["ssl_id" => $createOrder['result']->data->id, "organization_handle" => $orgnizationHandle];
-        $helper->insert_custom_fields_value($serviceId, $pid, $fields);
+        // $fields = ["ssl_id" => $createOrder['result']->data->id, "organization_handle" => $orgnizationHandle];
+        // $helper->insert_custom_fields_value($serviceId, $pid, $fields);
 
-        logModuleCall('Openprovider SSL', __FUNCTION__, $postData, $createOrder['result']);
+        // logModuleCall('Openprovider SSL', __FUNCTION__, $postData, $createOrder['result']);
+        logModuleCall('Openprovider SSL', __FUNCTION__, $postData, "Create order API call is commented for testing purpose");
         return "success";
     } catch (Exception $e) {
         logModuleCall('Openprovider SSL', __FUNCTION__, $params, $e->getMessage(), $e->getTraceAsString());

--- a/modules/servers/openprovider_ssl/openprovider_ssl.php
+++ b/modules/servers/openprovider_ssl/openprovider_ssl.php
@@ -356,9 +356,11 @@ function openprovider_ssl_CreateAccount(array $params)
             $orgnizationHandle = $handle;
         }
 
-        $domain = $params['customfields']['domain'] ?? '';
+        $domain = trim((string) ($params['customfields']['domain'] ?? ($params['domain'] ?? '')));
+        if ($domain === '') {
+            return 'Domain is required to create an SSL order.';
+        }
         $emailDomain = preg_replace('/^\*\./', '', $domain);
-
         $postData = [
             "approver_email" => $params['customfields']['approver_email'] . '@' . $emailDomain,
             "autorenew" => ($params['configoption2'] == 'on') ? 'on' : 'off',


### PR DESCRIPTION
Fix SSL order creation to use the domain from custom fields instead of the empty WHMCS domain parameter. Also handles wildcard domains correctly when generating the approver email.